### PR TITLE
fix: apply elm-safe-virtual-dom in the sandboxed build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ elm-stuff
 # elm-repl generated files
 repl-temp-*
 
+# files derived from elm-safe-virtual-dom
+elm-kernel-replacements
 
 node_modules
 

--- a/flake.lock
+++ b/flake.lock
@@ -60,6 +60,22 @@
         "type": "github"
       }
     },
+    "elmSafeVirtualDom": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750779589,
+        "narHash": "sha256-Wzz1mj42nv6Zcpo1ThXT8hkSQQSceREEcqBenNXVi6o=",
+        "owner": "lydell",
+        "repo": "elm-safe-virtual-dom",
+        "rev": "cee3aab245653461e89857a7ff96f8a5cfea7543",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lydell",
+        "repo": "elm-safe-virtual-dom",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -75,6 +91,54 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "lydellElmBrowser": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1742723029,
+        "narHash": "sha256-zC37DIRNaqW1I1ZEVXOeUbTlyEgubihLqMrp7JZZeLU=",
+        "owner": "lydell",
+        "repo": "browser",
+        "rev": "dc4614d8eb1d1a12aa12b4c2602801e9e07698c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lydell",
+        "repo": "browser",
+        "type": "github"
+      }
+    },
+    "lydellElmHtml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1748808494,
+        "narHash": "sha256-ugWjEuszB50l+EyOgLwDGrKxJxCDrxpzTzHrCDry3p4=",
+        "owner": "lydell",
+        "repo": "html",
+        "rev": "09257799949d6ef28756b1f03794acb0bab3af7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lydell",
+        "repo": "html",
+        "type": "github"
+      }
+    },
+    "lydellElmVirtualDom": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750779348,
+        "narHash": "sha256-1c+DzZhCL2HAwDa8W6gPsahO+VRI8wYArm1hfrGySwQ=",
+        "owner": "lydell",
+        "repo": "virtual-dom",
+        "rev": "8c20e5b9f309e82e67284669f3740132a2a4d9d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lydell",
+        "repo": "virtual-dom",
         "type": "github"
       }
     },
@@ -157,7 +221,11 @@
     "root": {
       "inputs": {
         "elm-review-tool-src": "elm-review-tool-src",
+        "elmSafeVirtualDom": "elmSafeVirtualDom",
         "flake-utils": "flake-utils",
+        "lydellElmBrowser": "lydellElmBrowser",
+        "lydellElmHtml": "lydellElmHtml",
+        "lydellElmVirtualDom": "lydellElmVirtualDom",
         "mkElmDerivation": "mkElmDerivation",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
           };
       in {
         packages = {
-          inherit built compiledElmApp elm-review-tool;
+          inherit built compiledElmApp elm-review-tool elmKernelReplacements;
           elm-review-tool-src = pkgs.runCommand "elm-review-tool-src" { }
             "ln -s ${elm-review-tool-src} $out";
           default = built;
@@ -113,8 +113,9 @@
           reviewSrc = peekSrc "elm-review" reviewSrc;
         };
         checks = { inherit built elmReviewed elmtests; };
-        devShells.default =
-          import ./nix/shell.nix { inherit elm-review-tool pkgs; };
+        devShells.default = import ./nix/shell.nix {
+          inherit elm-review-tool elmKernelReplacements pkgs;
+        };
         apps.default = {
           type = "app";
           program = "${pkgs.writeScript "tularsApp" ''

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ open: build
 build:
     nix build .
 
-# Use elm-live to get hot reloading.
+# Use elm-live to get hot reloading. NB: Applies patches to files in ELM_HOME.
 live:
     livedev
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,8 @@
 # manually replaced the next two lines:
 # { nixpkgs ? <nixpkgs>, config ? { } }:
 # with (import nixpkgs config);
-{ elmPackages, lib, pkgs, minimalElmSrc, nodePackages, stdenv }:
+{ elmKernelReplacements, elmPackages, lib, pkgs, minimalElmSrc, nodePackages
+, stdenv }:
 let
   mkDerivation = { srcs ? ./elm/elm-srcs-main.nix, src, name, srcdir ? "../src"
     , targets ? [ ], registryDat ? ./elm/registry.dat, outputJavaScript ? false
@@ -21,6 +22,14 @@ let
         extension = if outputJavaScript then "js" else "html";
       in ''
         ${pkgs.makeDotElmDirectoryCmd { elmJson = ../elm.json; }}
+
+        echo ELM_HOME is $ELM_HOME
+        echo "Creating elm-safe-virtual-dom's expected folder structure..."
+        cp -r ${elmKernelReplacements}/elm-kernel-replacements ./elm-kernel-replacements
+        echo "Done creating elm-safe-virtual-dom's expected folder structure."
+        ${pkgs.nodejs}/bin/node -e "import('./elm-kernel-replacements/replace-kernel-packages.mjs').then(m => m.replaceKernelPackages())"
+        echo "Done injecting elm-safe-virtual-dom's replacement kernel packages. 👍"
+
         mkdir -p $out/share/doc
         ${lib.concatStrings (map (module: ''
           echo "compiling ${elmfile module}"

--- a/nix/elm-kernel-replacements.nix
+++ b/nix/elm-kernel-replacements.nix
@@ -1,0 +1,62 @@
+{ elmSafeVirtualDom, elmVersion, lib, lydellElmBrowser, lydellElmHtml
+, lydellElmVirtualDom, pkgs, stdenv }:
+let
+  inherit (lib) fileset;
+  inherit (lib.asserts) assertMsg;
+
+  # These must match the original elm* versions in elm.json, for all projects this is applied to!
+  lydellVersions = {
+    browser = "1.0.2";
+    html = "1.0.0";
+    virtual-dom = "1.0.4";
+  };
+  depVersions = (lib.importJSON ../elm.json).dependencies;
+in assert assertMsg (depVersions.direct."elm/browser" == lydellVersions.browser)
+  "elm/browser version must match the Lydell patch";
+assert assertMsg (depVersions.direct."elm/html" == lydellVersions.html)
+  "elm/html version must match the Lydell patch";
+assert assertMsg
+  (depVersions.indirect."elm/virtual-dom" == lydellVersions.virtual-dom)
+  "elm/virtual-dom version must match the Lydell patch";
+stdenv.mkDerivation {
+  name =
+    "elm_kernel_replacements"; # deliberately unique spelling, so it's easy to find from error messages
+  dontUnpack = true;
+  buildPhase = ''
+    # the `assert` guards above will enforce that the versions in hippo/elm.json must exactly match the Lydell versions
+
+    echo "Creating elm-safe-virtual-dom's expected folder structure..."
+    mkdir -p ./elm-kernel-replacements/elm-stuff/elm
+    pushd ./elm-kernel-replacements/elm-stuff/elm
+    mkdir -p browser/${lydellVersions.browser}
+    mkdir -p html/${lydellVersions.html}
+    mkdir -p virtual-dom/${lydellVersions.virtual-dom}
+
+    cp -r ${lydellElmBrowser}/* ./browser/${lydellVersions.browser}
+    cp -r ${lydellElmHtml}/* ./html/${lydellVersions.html}
+    cp -r ${lydellElmVirtualDom}/* ./virtual-dom/${lydellVersions.virtual-dom}
+    popd
+    cp ${elmSafeVirtualDom}/replace-kernel-packages.mjs ./elm-kernel-replacements/
+    echo "Done creating elm-safe-virtual-dom's expected folder structure:"
+
+    ${pkgs.tree}/bin/tree -d .
+
+    cat << EOF
+    The expected file structure is ready!
+    To use it, link or copy this derivation's files into your project folder, then run something like:
+
+        node -e "import('./elm-kernel-replacements/replace-kernel-packages.mjs').then(m => m.replaceKernelPackages())"
+
+    That will apply the patched versions to your \$ELM_HOME folder, or ./elm-home/elm-stuff if
+    the ELM_HOME env var is not set.
+    From there, Elm will use the patched versions as if they were the originals.
+
+    More info: https://github.com/lydell/elm-safe-virtual-dom?tab=readme-ov-file#elm-safe-virtual-dom
+    EOF
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./elm-kernel-replacements $out
+  '';
+}

--- a/nix/elmReviewed.nix
+++ b/nix/elmReviewed.nix
@@ -1,8 +1,5 @@
-{ elm-review-tool, elmPackages, lib, pkgs, stdenv, reviewSrc }:
-let
-  elmVersion = "0.19.1";
-
-  mainApp = builtins.fromJSON (builtins.readFile ../elm.json);
+{ elm-review-tool, elmPackages, elmVersion, lib, pkgs, stdenv, reviewSrc }:
+let mainApp = builtins.fromJSON (builtins.readFile ../elm.json);
 
 in stdenv.mkDerivation {
   name = "elm-reviewed";

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,7 +1,14 @@
-{ elm-review-tool, pkgs }:
+{ elm-review-tool, elmKernelReplacements, pkgs }:
 let
   liveDev = pkgs.writeScriptBin "livedev" ''
     cd "$(git rev-parse --show-toplevel)"
+    export ELM_HOME="''${ELM_HOME:-$(realpath ./elm-home/elm-stuff)}"
+    mkdir -p "$ELM_HOME"
+    echo "⚠️ elm-safe-virtual-dom will now patch YOUR local ELM_HOME files, under ''${ELM_HOME:-./elm-home/elm-stuff}."
+    echo "🛈️ Don't forget to clear ./elm-stuff each time you remove/apply these patches, or you'll get weird results!"
+    rm -rf ./elm-kernel-replacements
+    cp --no-preserve=mode -r "${elmKernelReplacements}"/elm-kernel-replacements ./
+    ${pkgs.nodejs}/bin/node -e "import('./elm-kernel-replacements/replace-kernel-packages.mjs').then(m => m.replaceKernelPackages())"
     elm-live app/Main.elm -d dist -Hu -- --output="dist/Main.js"
   '';
 in pkgs.mkShell {


### PR DESCRIPTION
Applies [lydell/elm-safe-virtual-dom](https://github.com/lydell/elm-safe-virtual-dom) to an Elm project, that takes place inside a sandboxed Nix build.

The upstream sources have deliberately not been copied / 'vendored' into this repo.
That makes it easier to later get updates, using commands like `nix flake update elmSafeVirtualDom lydellElmBrowser`, etc etc.

The patched packages are also available outside the sandboxed build, eg to elm-live: e163a53ba0143c8cbef781f3fde61a6442e8317e
